### PR TITLE
Reverse Chronological order of Conferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,81 +10,81 @@ If you would like to be notified of future conferences that would be added to th
 
 | Conference | Date | Venue | Description |
 |------------|------|-------|-------------|
-| [Hosting and Domain Conference India](http://www.hdcon.org/) | 3 Feb | Hyderabad | Hosting and Domain Conference is the World's Top initiative to discuss on latest happenings in the field of web technologies. Hosting, Domain, Blogging and Web technologies are major discussions. |
-| [PyCon Pune](https://pune.pycon.org/2018/) | 08-11 Feb | Pune | The community will meet for two days of talks and work on upstream projects in two days of dev sprint. |
-| [GopherCon India](http://www.gophercon.in/) | 09-10 Mar | Sheraton Grand, Sangamvadi, Pune | Go conference in India. Go is an open source project developed by a team at Google and many contributors from the open source community. |
 | [Great Indian Developer Summit](http://www.developermarch.com/developersummit/index.html) | 24-27 Apr | Bengaluru | 	With over 40000 attendees benefiting from ten game changing editions, GIDS is the gold standard for India's software professional ecosystem.
+| [GopherCon India](http://www.gophercon.in/) | 09-10 Mar | Sheraton Grand, Sangamvadi, Pune | Go conference in India. Go is an open source project developed by a team at Google and many contributors from the open source community. |
+| [PyCon Pune](https://pune.pycon.org/2018/) | 08-11 Feb | Pune | The community will meet for two days of talks and work on upstream projects in two days of dev sprint. |
+| [Hosting and Domain Conference India](http://www.hdcon.org/) | 3 Feb | Hyderabad | Hosting and Domain Conference is the World's Top initiative to discuss on latest happenings in the field of web technologies. Hosting, Domain, Blogging and Web technologies are major discussions. |
 
 ## 2017
 
 | Conference | Date | Venue | Description |
 |------------|------|-------|-------------|
-| [WikiToLearn India Conference 2017](https://india2017.wikitolearn.events) | 18-19 Jan | THE LNMIIT, Jaipur | WikiToLearnConf India is a global event comprising WikiToLearn, Mediawiki and KDE developers from all over India and world. |
-| [50pConf](https://50p.in/2017/) | 24-25 Jan | MLR Convention Centre, Bengaluru | A conference on India's payments ecosystem. |
-| [RubyConf India](http://rubyconfindia.org/) | 27-29 Jan | Le Meridien, Kochi |  RubyConf India is a global event complementing other RubyConf events across the world. |
-| [PyCon Pune](https://pune.pycon.org/) | 16-19 Feb | College of Engineering Pune |  The gathering for the community using and developing the open-source Python programming language. |
-| [GopherCon India](http://www.gophercon.in/) | 24-25 Feb | Hyatt Regency, Pune | Go conference in India. Go is an open source project developed by a team at Google and many contributors from the open source community. |
-| [Women Who Code Connect- India](https://sites.google.com/view/wwcconnectindia/) | 3 Mar | VMWare, Kalyani Vista, Bengaluru | A part of the Women Technology Conference series by Women Who Code. |
-| [FOSSMeet](http://fossmeet.in/2017/) | 10-12 Mar | NIT Calicut | FOSSMeet is an annual event on Free and Open source software, conducted at National Institute of Technology, Calicut. |
-| [PyDelhi Conf](https://conference.pydelhi.org/) | 18-19 Mar | IIM Lucknow Noida Campus, Noida | PyDelhi conference is hosted annually by PyDelhi Community with an aim to promote Python programming language. |
-| [LaravelLive India](https://laravellive.in/) | 19 Mar | New Delhi | A PHP Laravel Conference. |
-| [Banglore Container Conference](http://www.containerconf.in/) | 7 Apr | Park Plaza (5 star), ORR, Bengaluru | Bengaluru Container Conference 2017 (BCC ’17) is the first conference on container technologies in India. |
-| [GIDS](http://www.developermarch.com/developersummit/) | 25-28 April | J. N. Tata Auditorium, Bengaluru | With over 40000 attendees benefiting from ten game changing editions, GIDS is the gold standard for India's software professional ecosystem.  |
-| [Oracle Code New Delhi](https://developer.oracle.com/code/newdelhi) | 09-10 May | Pragati Maidan New Delhi | Oracle Code is a free event for developers to learn about the latest developer technologies, practices, and trends. |
-| [RootConf](https://rootconf.in/2017/) | 11-12 May | MLR Convention Centre, Bengaluru | Rootconf is India’s principal conference where systems and operations engineers share real world knowledge about building resilient and scalable systems. |
-| [Amazon AWS Summit](https://aws.amazon.com/summits/new_delhi/) | 12 May | JW Marriott Hotel New Delhi | The AWS Summit brings together the cloud computing community to connect, collaborate and learn about AWS.|
-| [Ethereum India Summit](https://in.explara.com/e/blockchainstormethereumindia2017) | 18 May | Hotel Taj Mahal Palace, Mumbai | India’s first ever Ethereum Summit with Ethereum CoFounder Vitalik Buterin. |
-| [HillHacks](https://hillhacks.in/) | 15-31 May | Bir, Himachal Pradesh | People from different places, walks of life and lines of thought come together to share, collaborate and learn.|
-| [India Cloud Summit](http://www.cloudsummit.org/) | 5 July | Bengaluru | It is an event covering topics, like architecture, performance, operations and more. |
-| [AlterConf](https://alterconf.com/conferences/bangalore-india) (postponed to 2018) | 8 July | Microsoft Signature Building, Bengaluru | AlterConf is a traveling conference series that provides safe opportunities for marginalized people and those who support them in the tech and gaming industries. |
-| [SANOG](http://www.sanog.org/sanog30/) | 10-18 July | Ramada Gurgaon Central, Gurgaon, Haryana, India | The South Asian Network Operator Group. Engineers sharing operational knowledge on running ISPs and modern networks. |
-| [The Fifth Elephant](https://fifthelephant.in/2017/) | 27-28 July | MLR Convention Centre, Whitefield, Bengaluru | The Fifth Elephant is India’s most renowned conference on data, a space for discussing the most relevant tools, techniques and frameworks with expert practitioners in the field. |
-| [Anthill Inside](https://anthillinside.in/2017/) | 29 July | MLR Convention Centre, Whitefield, Bengaluru | Anthill Inside is the new avataar of the Deep Learning conference.|
-| [Eclipse Summit India](https://eclipsesummit.in/) | 29 July | Infosys Campus, Electronic City, Bengaluru | This is a great opportunity for the Eclipse fraternity in India to learn, explore, share, and collaborate on the latest ideas and information about Eclipse ecosystem and its community of projects with the core contributors, adopters, extenders, service providers, consumers and business and research organizations. |
-| [JS Channel](http://2017.jschannel.com/) | 28-29 July | JW Marriott Hotel, Bengaluru | JS Channel is a unique platform to hear best of the bests speakers in JS Community along with learning from expert JS trainers in workshop/live-coding sessions. |
-| [Oracle Code Bengaluru ](https://developer.oracle.com/code/bangalore) | 10 August | Bengaluru, Karnataka | Oracle Code is a free event for developers to learn about the latest developer technologies, practices, and trends.|
-|[Data Visualization Summit](http://www.unicomlearning.com/2017/Data_Visualization_Summit_Mumbai/)| 1 September| Mumbai | A primary goal of data visualization is to communicate information clearly and efficiently via statistical graphics. |
-| [DevOps++ Global Summit](https://www.townscript.com/e/devopsglobalsummitdoppa2017) | 9 Sept | Pune | It is a way to get the community together and experience the latest in DevOps and beyond. The ++ in DevOps++ is all about going beyond DevOps. |
-| [Fragments 2017](https://hasgeek.com/) | 12-13 Sept | Bengaluru | Fragments is a two-day conference on the mobile ecosystem in India. |
-| [CloudSec](https://www.cloudsec.com/in/) | 13 Sept | JW Marriott, Mumbai | It is a conference about IT Security Technologies, Policies and Compliance. |
-| [ReactFoo 2017](https://hasgeek.com/) | 14 Sept | Bengaluru | ReactFoo is a single-day React conference by HasGeek. |
-| [DevOps Days India](https://devopsdaysindia.org/) | 15-16 Sept | Hotel Vivanta by Taj, MG Road, Bengaluru | DevOpsDays India is a global event complementing other DevOpsDays events across the world. |
-| [JSFoo](https://jsfoo.in/2017/) | 15-16 Sept | MLR Convention Centre, Bengaluru | JSFoo is India’s premier JavaScript conference, hosted by HasGeek. The broad theme this year is building reliable web apps.  |
-| [DevOps Summit](http://www.unicomlearning.com/2017/DevOps_Summit_Pune/) | 16 Sept | Pune | The conference brings together leading practitioner-organisations who have achieved Continuous Delivery and organisational transformation. |
-| [CYPHER 2017](http://www.analyticsindiasummit.com/about/) | 21-23 Sept | Hotel Park Plaza, Bengaluru | A platform to network and learn from the leading thought leaders, companies and startups in Analytics, Data Science and Artificial Intelligence discipline. |
-| [India Blockchain Week](https://www.indiablockchainweek.com/)| 22-26 September | Leela Hotel, Mumbai| Blockchain technology has created waves around the World, bringing transparency and massively reducing costs. |
-| [ICCE 2017](http://www.icce-asia2017.org/) | 05-07 Oct | Bengaluru | 2nd International Conference on Consumer Electronics Asia |
-| [PyConf Hyderabad](http://pyconf.hydpy.org/) | 07-08 Oct | IIIT Hyderabad, Hyderabad | First Python Conference in Hyderabad for the development of Python programming language. |
-| [Open Source India 2017](http://opensourceindia.in/osidays/) | 13-14 Oct | Bengaluru, NIMHANS Convention Center | Open Source India brings the open source community to one floor, to explore what’s new and exciting in open source languages, tools, and techniques. |
-| [PyCon India](https://in.pycon.org/2017/) | 2-5 Nov | Jawahar Lal Nehru University, New Delhi | The premier conference in India on using and developing the Python programming language. |
-| [DataHack Summit](https://www.analyticsvidhya.com/datahacksummit/) | 9-11 Nov | Bengaluru | DataHack Summit is an initiative by Analytics Vidhya to bring together the finest data scientists from across the country & globe. |
-| [Grace Hopper Celebration India (GHCI)](https://ghcindia.anitaborg.org/) | 16-17 Nov |  Bengaluru International Exhibition Center (BIEC), Bengaluru | The Grace Hopper Celebration of Women in Computing (India) is India's largest gathering of women technologists. |
-| [try! swift](https://www.tryswift.co/events/2017/bangalore/) | 16-17 Nov | MLR Convention Centre, Bengaluru | try! Swift India is an amazing chance for developers in the Asian Pacific region to learn the latest world trends in iOS, tvOS, and watchOS development using the industry's best standards. |
-| [Functional Conf](https://functionalconf.com/) | 16-19 Nov | Bengaluru | Asia's Premier Functional Programming Conference, designed to bring the growing community of functional programmers together under one roof. |
-| [XP Conference India 2017](http://xpconference.in/2017XpConf/) | 17-18 Nov | Bengaluru | The 3rd International XP Conference on Agile Engineering practices for software product development, hosted by Volunteers and the community at large. |
 | [World Cloud Summit](http://worldcloudsummit.com/) | 23-24 Nov | Jaipur | World Cloud Summit is one of the largest gatherings of cloud services and internet infrastructure industries. |
+| [XP Conference India 2017](http://xpconference.in/2017XpConf/) | 17-18 Nov | Bengaluru | The 3rd International XP Conference on Agile Engineering practices for software product development, hosted by Volunteers and the community at large. |
+| [Functional Conf](https://functionalconf.com/) | 16-19 Nov | Bengaluru | Asia's Premier Functional Programming Conference, designed to bring the growing community of functional programmers together under one roof. |
+| [try! swift](https://www.tryswift.co/events/2017/bangalore/) | 16-17 Nov | MLR Convention Centre, Bengaluru | try! Swift India is an amazing chance for developers in the Asian Pacific region to learn the latest world trends in iOS, tvOS, and watchOS development using the industry's best standards. |
+| [Grace Hopper Celebration India (GHCI)](https://ghcindia.anitaborg.org/) | 16-17 Nov |  Bengaluru International Exhibition Center (BIEC), Bengaluru | The Grace Hopper Celebration of Women in Computing (India) is India's largest gathering of women technologists. |
+| [DataHack Summit](https://www.analyticsvidhya.com/datahacksummit/) | 9-11 Nov | Bengaluru | DataHack Summit is an initiative by Analytics Vidhya to bring together the finest data scientists from across the country & globe. |
+| [PyCon India](https://in.pycon.org/2017/) | 2-5 Nov | Jawahar Lal Nehru University, New Delhi | The premier conference in India on using and developing the Python programming language. |
+| [Open Source India 2017](http://opensourceindia.in/osidays/) | 13-14 Oct | Bengaluru, NIMHANS Convention Center | Open Source India brings the open source community to one floor, to explore what’s new and exciting in open source languages, tools, and techniques. |
+| [PyConf Hyderabad](http://pyconf.hydpy.org/) | 07-08 Oct | IIIT Hyderabad, Hyderabad | First Python Conference in Hyderabad for the development of Python programming language. |
+| [ICCE 2017](http://www.icce-asia2017.org/) | 05-07 Oct | Bengaluru | 2nd International Conference on Consumer Electronics Asia |
+| [India Blockchain Week](https://www.indiablockchainweek.com/)| 22-26 September | Leela Hotel, Mumbai| Blockchain technology has created waves around the World, bringing transparency and massively reducing costs. |
+| [CYPHER 2017](http://www.analyticsindiasummit.com/about/) | 21-23 Sept | Hotel Park Plaza, Bengaluru | A platform to network and learn from the leading thought leaders, companies and startups in Analytics, Data Science and Artificial Intelligence discipline. |
+| [DevOps Summit](http://www.unicomlearning.com/2017/DevOps_Summit_Pune/) | 16 Sept | Pune | The conference brings together leading practitioner-organisations who have achieved Continuous Delivery and organisational transformation. |
+| [JSFoo](https://jsfoo.in/2017/) | 15-16 Sept | MLR Convention Centre, Bengaluru | JSFoo is India’s premier JavaScript conference, hosted by HasGeek. The broad theme this year is building reliable web apps.  |
+| [DevOps Days India](https://devopsdaysindia.org/) | 15-16 Sept | Hotel Vivanta by Taj, MG Road, Bengaluru | DevOpsDays India is a global event complementing other DevOpsDays events across the world. |
+| [ReactFoo 2017](https://hasgeek.com/) | 14 Sept | Bengaluru | ReactFoo is a single-day React conference by HasGeek. |
+| [CloudSec](https://www.cloudsec.com/in/) | 13 Sept | JW Marriott, Mumbai | It is a conference about IT Security Technologies, Policies and Compliance. |
+| [Fragments 2017](https://hasgeek.com/) | 12-13 Sept | Bengaluru | Fragments is a two-day conference on the mobile ecosystem in India. |
+| [DevOps++ Global Summit](https://www.townscript.com/e/devopsglobalsummitdoppa2017) | 9 Sept | Pune | It is a way to get the community together and experience the latest in DevOps and beyond. The ++ in DevOps++ is all about going beyond DevOps. |
+|[Data Visualization Summit](http://www.unicomlearning.com/2017/Data_Visualization_Summit_Mumbai/)| 1 September| Mumbai | A primary goal of data visualization is to communicate information clearly and efficiently via statistical graphics. |
+| [Oracle Code Bengaluru ](https://developer.oracle.com/code/bangalore) | 10 August | Bengaluru, Karnataka | Oracle Code is a free event for developers to learn about the latest developer technologies, practices, and trends.|
+| [JS Channel](http://2017.jschannel.com/) | 28-29 July | JW Marriott Hotel, Bengaluru | JS Channel is a unique platform to hear best of the bests speakers in JS Community along with learning from expert JS trainers in workshop/live-coding sessions. |
+| [Eclipse Summit India](https://eclipsesummit.in/) | 29 July | Infosys Campus, Electronic City, Bengaluru | This is a great opportunity for the Eclipse fraternity in India to learn, explore, share, and collaborate on the latest ideas and information about Eclipse ecosystem and its community of projects with the core contributors, adopters, extenders, service providers, consumers and business and research organizations. |
+| [Anthill Inside](https://anthillinside.in/2017/) | 29 July | MLR Convention Centre, Whitefield, Bengaluru | Anthill Inside is the new avataar of the Deep Learning conference.|
+| [The Fifth Elephant](https://fifthelephant.in/2017/) | 27-28 July | MLR Convention Centre, Whitefield, Bengaluru | The Fifth Elephant is India’s most renowned conference on data, a space for discussing the most relevant tools, techniques and frameworks with expert practitioners in the field. |
+| [SANOG](http://www.sanog.org/sanog30/) | 10-18 July | Ramada Gurgaon Central, Gurgaon, Haryana, India | The South Asian Network Operator Group. Engineers sharing operational knowledge on running ISPs and modern networks. |
+| [AlterConf](https://alterconf.com/conferences/bangalore-india) (postponed to 2018) | 8 July | Microsoft Signature Building, Bengaluru | AlterConf is a traveling conference series that provides safe opportunities for marginalized people and those who support them in the tech and gaming industries. |
+| [India Cloud Summit](http://www.cloudsummit.org/) | 5 July | Bengaluru | It is an event covering topics, like architecture, performance, operations and more. |
+| [HillHacks](https://hillhacks.in/) | 15-31 May | Bir, Himachal Pradesh | People from different places, walks of life and lines of thought come together to share, collaborate and learn.|
+| [Ethereum India Summit](https://in.explara.com/e/blockchainstormethereumindia2017) | 18 May | Hotel Taj Mahal Palace, Mumbai | India’s first ever Ethereum Summit with Ethereum CoFounder Vitalik Buterin. |
+| [Amazon AWS Summit](https://aws.amazon.com/summits/new_delhi/) | 12 May | JW Marriott Hotel New Delhi | The AWS Summit brings together the cloud computing community to connect, collaborate and learn about AWS.|
+| [RootConf](https://rootconf.in/2017/) | 11-12 May | MLR Convention Centre, Bengaluru | Rootconf is India’s principal conference where systems and operations engineers share real world knowledge about building resilient and scalable systems. |
+| [Oracle Code New Delhi](https://developer.oracle.com/code/newdelhi) | 09-10 May | Pragati Maidan New Delhi | Oracle Code is a free event for developers to learn about the latest developer technologies, practices, and trends. |
+| [GIDS](http://www.developermarch.com/developersummit/) | 25-28 April | J. N. Tata Auditorium, Bengaluru | With over 40000 attendees benefiting from ten game changing editions, GIDS is the gold standard for India's software professional ecosystem.  |
+| [Banglore Container Conference](http://www.containerconf.in/) | 7 Apr | Park Plaza (5 star), ORR, Bengaluru | Bengaluru Container Conference 2017 (BCC ’17) is the first conference on container technologies in India. |
+| [LaravelLive India](https://laravellive.in/) | 19 Mar | New Delhi | A PHP Laravel Conference. |
+| [PyDelhi Conf](https://conference.pydelhi.org/) | 18-19 Mar | IIM Lucknow Noida Campus, Noida | PyDelhi conference is hosted annually by PyDelhi Community with an aim to promote Python programming language. |
+| [FOSSMeet](http://fossmeet.in/2017/) | 10-12 Mar | NIT Calicut | FOSSMeet is an annual event on Free and Open source software, conducted at National Institute of Technology, Calicut. |
+| [Women Who Code Connect- India](https://sites.google.com/view/wwcconnectindia/) | 3 Mar | VMWare, Kalyani Vista, Bengaluru | A part of the Women Technology Conference series by Women Who Code. |
+| [GopherCon India](http://www.gophercon.in/) | 24-25 Feb | Hyatt Regency, Pune | Go conference in India. Go is an open source project developed by a team at Google and many contributors from the open source community. |
+| [PyCon Pune](https://pune.pycon.org/) | 16-19 Feb | College of Engineering Pune |  The gathering for the community using and developing the open-source Python programming language. |
+| [RubyConf India](http://rubyconfindia.org/) | 27-29 Jan | Le Meridien, Kochi |  RubyConf India is a global event complementing other RubyConf events across the world. |
+| [50pConf](https://50p.in/2017/) | 24-25 Jan | MLR Convention Centre, Bengaluru | A conference on India's payments ecosystem. |
+| [WikiToLearn India Conference 2017](https://india2017.wikitolearn.events) | 18-19 Jan | THE LNMIIT, Jaipur | WikiToLearnConf India is a global event comprising WikiToLearn, Mediawiki and KDE developers from all over India and world. |
 
 ## 2016
 
 | Conference | Date | Venue | Description |
 |------------|------|-------|-------------|
-|[Mini Deb-Con](http://in2015.mini.debconf.org/)|30 - 31 January| Andheri (E), Mumbai | It is an awesome opportunity for any user who wants to experience the magic of FOSS |
-| [GopherCon India](http://www.gophercon.in/) | 19-20 Feb | Vivanta by Taj, Bengaluru | Go conference in India. Go is an open source project developed by a team at Google and many contributors from the open source community. |
-| [FOSSMeet](http://fossmeet.in/2016/) | 26-28 Feb | NIT Calicut | FOSSMeet is an annual event on Free and Open source software, conducted at National Institute of Technology, Calicut. |
-| [PyDelhi Conf](https://conference.pydelhi.org/2016/) | 5 Mar | Jawaharlal Nehru University, Delhi | PyDelhi conference is hosted annually by PyDelhi Community with an aim to promote Python programming language. |
-| [RubyConf India](http://rubyconfindia.org/rci2016/) | 19-20 Mar | Le Meridien, Kochi |  RubyConf India is a global event complementing other RubyConf events across the world. |
-| [IndiaHacks Conference](https://www.hackerearth.com/indiahacks-conference/) | 19 Mar | Vivanta by Taj, Bengaluru | Conducted by HackerEarth,the conference has an extensive lineup of speakers talking on a variety of technical subjects like Machine Learning, Big Data, Artificial Intelligence, Scientific Computing, etc. |
-| [Rootconf](https://rootconf.in/2016/) | 14-15 Apr | MLR Convention Centre, Bengaluru | Rootconf is India’s principal conference where systems and operations engineers share real world knowledge about building resilient and scalable systems. |
-| [The Fifth Elephant](https://fifthelephant.in/2016/) | 28-29 July | NIMHANS Convention Centre, Bengaluru | The Fifth Elephant is India’s most renowned conference on data, a space for discussing the most relevant tools, techniques and frameworks with expert practitioners in the field. |
-| [SANOG](http://www.sanog.org/sanog28/) | 1-9 August | Trident, BKC, Mumbai | The South Asian Network Operator Group. Engineers sharing operational knowledge on running ISPs and modern networks. |
-| [JSFoo](https://jsfoo.in/2016/) | 15-16 Sept | MLR Convention Centre, Bengaluru | JSFoo is India’s premier JavaScript conference. |
-| [Meta Refresh](https://metarefresh.in/2016/) | 17 Sept | MLR Convention Centre, Bengaluru | Meta Refresh is an event on front-end engineering and design. |
-| [PyCon India](https://in.pycon.org/2016/) | 24-25 Sept | Jawahar Lal Nehru University, New Delhi | The premier conference in India on using and developing the Python programming language. |
-| [UX India](http://www.2016.ux-india.org/) | 20-22 Oct | Westin, Hyderabad | India’s biggest international conference on user experience design. |
-| [DevOps Days India](http://devopsdaysindia.org/) | 4-5 Nov | The Royal Orchind, Bengaluru | DevOpsDays India is a global event complementing other DevOpsDays events across the world. |
-| [droidconIN](https://droidcon.in/2016/) | 10-11 Nov | MLR Convention Centre, Bengaluru | It is the biggest android conference in the region and is the place to be if you are into android development, design or architecture. |
-| [OpenDayLight India Fourm](http://events.linuxfoundation.org/events/opendaylight-forum-india) | 16-17 Nov | Sheraton Grand Hotel Bengaluru, Bengaluru | The networking industry has come to fully emrbace open source SDN as the right path towards achieving innovation and interoperability in today's infrastructures. |
 | [Grace Hopper Conference India](http://ghcindia.anitaborg.org/) | 7-9 Dec | Vivanta by Taj, Bengaluru | It is India's largest gathering of women technologists produced by the Anita Borg Institute and presented in partnership with ACM India. |
+| [OpenDayLight India Fourm](http://events.linuxfoundation.org/events/opendaylight-forum-india) | 16-17 Nov | Sheraton Grand Hotel Bengaluru, Bengaluru | The networking industry has come to fully emrbace open source SDN as the right path towards achieving innovation and interoperability in today's infrastructures. |
+| [droidconIN](https://droidcon.in/2016/) | 10-11 Nov | MLR Convention Centre, Bengaluru | It is the biggest android conference in the region and is the place to be if you are into android development, design or architecture. |
+| [DevOps Days India](http://devopsdaysindia.org/) | 4-5 Nov | The Royal Orchind, Bengaluru | DevOpsDays India is a global event complementing other DevOpsDays events across the world. |
+| [UX India](http://www.2016.ux-india.org/) | 20-22 Oct | Westin, Hyderabad | India’s biggest international conference on user experience design. |
+| [PyCon India](https://in.pycon.org/2016/) | 24-25 Sept | Jawahar Lal Nehru University, New Delhi | The premier conference in India on using and developing the Python programming language. |
+| [Meta Refresh](https://metarefresh.in/2016/) | 17 Sept | MLR Convention Centre, Bengaluru | Meta Refresh is an event on front-end engineering and design. |
+| [JSFoo](https://jsfoo.in/2016/) | 15-16 Sept | MLR Convention Centre, Bengaluru | JSFoo is India’s premier JavaScript conference. |
+| [SANOG](http://www.sanog.org/sanog28/) | 1-9 August | Trident, BKC, Mumbai | The South Asian Network Operator Group. Engineers sharing operational knowledge on running ISPs and modern networks. |
+| [The Fifth Elephant](https://fifthelephant.in/2016/) | 28-29 July | NIMHANS Convention Centre, Bengaluru | The Fifth Elephant is India’s most renowned conference on data, a space for discussing the most relevant tools, techniques and frameworks with expert practitioners in the field. |
+| [Rootconf](https://rootconf.in/2016/) | 14-15 Apr | MLR Convention Centre, Bengaluru | Rootconf is India’s principal conference where systems and operations engineers share real world knowledge about building resilient and scalable systems. |
+| [IndiaHacks Conference](https://www.hackerearth.com/indiahacks-conference/) | 19 Mar | Vivanta by Taj, Bengaluru | Conducted by HackerEarth,the conference has an extensive lineup of speakers talking on a variety of technical subjects like Machine Learning, Big Data, Artificial Intelligence, Scientific Computing, etc. |
+| [RubyConf India](http://rubyconfindia.org/rci2016/) | 19-20 Mar | Le Meridien, Kochi |  RubyConf India is a global event complementing other RubyConf events across the world. |
+| [PyDelhi Conf](https://conference.pydelhi.org/2016/) | 5 Mar | Jawaharlal Nehru University, Delhi | PyDelhi conference is hosted annually by PyDelhi Community with an aim to promote Python programming language. |
+| [FOSSMeet](http://fossmeet.in/2016/) | 26-28 Feb | NIT Calicut | FOSSMeet is an annual event on Free and Open source software, conducted at National Institute of Technology, Calicut. |
+| [GopherCon India](http://www.gophercon.in/) | 19-20 Feb | Vivanta by Taj, Bengaluru | Go conference in India. Go is an open source project developed by a team at Google and many contributors from the open source community. |
+|[Mini Deb-Con](http://in2015.mini.debconf.org/)|30 - 31 January| Andheri (E), Mumbai | It is an awesome opportunity for any user who wants to experience the magic of FOSS |
 
 # <a name="contribute"/>Contributing </a>
 
@@ -96,6 +96,6 @@ To contribute to the list, please send a PR. If you don't have time to send in a
 
 ` | [name-of-conf](link) | date | venue | description |`
 
-Please make sure that the conferences are in chronological order and you follow the Pull Request Template. :smile:
+Please make sure that the conferences are in reverse chronological order and you follow the Pull Request Template. :smile:
 
 Contributions are more than welcome, please don't hesitate to contribute!


### PR DESCRIPTION
Displaying the events/conferences in a reverse chronological order
within each year makes it easier to quickly search for which events
are remaining in an year.
This also makes sure that the latest information is available with
minimal scrolling.
