### PR TITLE
Add India Blockchain week

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ To add a conference to the list, please [contribute](#contributing)!
 | Conference | Date | Venue | Description |
 |------------|------|-------|-------------|
 | [JSFoo](https://jsfoo.in/2018/) | 13-14 Sep | Bengaluru | The eighth edition of India’s first JavaScript conference.
+| [India Blockchain Week](https://www.indiablockchainweek.com/) | 9 Sep | Mumbai | Blockchain Conference with Blockchain hackathon. |
 | [PyCon India](https://in.pycon.org/2018/) | 22-26 Aug | Bengaluru International Exhibition Center (BIEC), Bengaluru | The premier conference in India on using and developing the Python programming language. |
 | [Great Indian Developer Summit](http://www.developermarch.com/developersummit/index.html) | 24-27 Apr | Bengaluru | 	With over 40000 attendees benefiting from ten game changing editions, GIDS is the gold standard for India's software professional ecosystem. |
 | [GopherCon India](http://www.gophercon.in/) | 09-10 Mar | Sheraton Grand, Sangamvadi, Pune | Go conference in India. Go is an open source project developed by a team at Google. |


### PR DESCRIPTION
Add India Blockchain week to the list.

<!--  Thanks for sending a pull request! You are awesome! :)
-->


**Details of the conference**:

- Website: https://www.indiablockchainweek.com/
- Date: 9 Sep
- Venue: Mumbai
- Description: Blockchain Conference with Blockchain hackathon.
