### PR TITLE
Add Deccan RubyConf 2018

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ To add a conference to the list, please [contribute](#contributing)!
 |------------|------|-------|-------------|
 | [PyCon India](https://in.pycon.org/2018/) | 05-09 Oct | Hyderabad International Convention Centre (HICC), Hyderabad | The premier conference in India on using and developing the Python programming language. |
 | [JSFoo](https://jsfoo.in/2018/) | 13-14 Sep | Bengaluru | The eighth edition of India’s first JavaScript conference.
+| [Deccan RubyConf 2018](https://www.deccanrubyconf.org/) | 4 Aug | Sheraton Grand Hotel, Pune | Pune extension of RubyConf India organized by same folks organizing RubyConf India |
 | [World Satoshi Summit](https://www.worldsatoshisummit.com/) | 12-13 May | New Delhi | Bring all the students, entrepreneurs, blockchain enthusiasts, blockchain developers and influencers under one roof for a seamless exchange of ideas. |
 | [Great Indian Developer Summit](http://www.developermarch.com/developersummit/index.html) | 24-27 Apr | Bengaluru | 	With over 40000 attendees benefiting from ten game changing editions, GIDS is the gold standard for India's software professional ecosystem. |
 | [Distributed Systems Conference 2018](https://dsconf.in/) | 21 Apr | Sheraton Grand Hotel, Pune | DSConf is a conference on the best practices and the future of Distributed Systems. The conference aims at helping grow & highlighting all the work in the areas of Distributed Systems. |


### PR DESCRIPTION
<!--  Thanks for sending a pull request! You are awesome! :)
-->


**Details of the conference**:

- Website: https://www.deccanrubyconf.org/
- Date: 4th Aug. 2018
- Venue: Sheraton Grand Hotel, Pune
- Description: Pune extension of RubyConf India organized by same folks organizing RubyConf India
