### PR TITLE
Updated the dates for JSFoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ To add a conference to the list, please [contribute](#contributing)!
 |------------|------|-------|-------------|
 | [FunctionalConf](https://functionalconf.com/) | 12-16 Dec | The LaLiT Ashok Hotel, Bengaluru | Bring together the growing community of functional programmers under one roof. |
 | [Devops Days India](http://devopsdaysindia.org/) | 8-9 Dec | Sheraton Grand, Bengaluru | Devopsdays is a worldwide series of technical conferences covering topics of software development, IT infrastructure operations, and the intersection between them. | 
+| [JSFoo](https://jsfoo.in/2018/) | 26-27 Oct | NIMHANS Convention Centre, Bengaluru | The eighth edition of India’s first JavaScript conference.|
 | [PyCon India](https://in.pycon.org/2018/) | 05-09 Oct | Hyderabad International Convention Centre (HICC), Hyderabad | The premier conference in India on using and developing the Python programming language. |
-| [JSFoo](https://jsfoo.in/2018/) | 13-14 Sep | Bengaluru | The eighth edition of India’s first JavaScript conference.|
 | [ODSC (One Data Science Conference) ](https://india.odsc.com/) | 30 Aug – 2 Sep | Hotel Lalit Ashok, Bengaluru  | Conference on AI and Data Science |
 | [ReactFoo-Delhi](https://reactfoo.in/2018-delhi/) | 18 Aug | TBA | React, alternatives to React, React Native and front-end engineering. |
 | [DevConf.in 2018](https://devconf.info/in) | 4-5 Aug | Christ University - Bengaluru | Annual Developers' Conference organised by Red Hat for local FOSS community |


### PR DESCRIPTION
Updated the dates and venue for JSFoo as per https://jsfoo.in/2018/

<!--  Thanks for sending a pull request! You are awesome! :)
-->


**Details of the conference**:

- Website: https://jsfoo.in/2018/
- Date: 26-27 Oct
- Venue: NIMHANS Convention Centre, Bangalore
- Description: The eighth edition of India’s first JavaScript conference
