### PR TITLE
Updating the venue details for ReactFoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To add a conference to the list, please [contribute](#contributing)!
 | [PyCon India](https://in.pycon.org/2018/) | 05-09 Oct | Hyderabad International Convention Centre (HICC), Hyderabad | The premier conference in India on using and developing the Python programming language. |
 | [JSFoo](https://jsfoo.in/2018/) | 13-14 Sep | Bengaluru | The eighth edition of India’s first JavaScript conference.|
 | [ODSC (One Data Science Conference) ](https://india.odsc.com/) | 30 Aug – 2 Sep | Hotel Lalit Ashok, Bengaluru  | Conference on AI and Data Science |
-| [ReactFoo-Delhi](https://reactfoo.in/2018-delhi/) | 18 Aug | TBA | React, alternatives to React, React Native and front-end engineering. |
+| [ReactFoo-Delhi](https://reactfoo.in/2018-delhi/) | 18 Aug | India International Centre, Max Mueller Marg, New Delhi | React, alternatives to React, React Native and front-end engineering. |
 | [DevConf.in 2018](https://devconf.info/in) | 4-5 Aug | Christ University - Bengaluru | Annual Developers' Conference organised by Red Hat for local FOSS community |
 | [Deccan RubyConf 2018](https://www.deccanrubyconf.org/) | 4 Aug | Sheraton Grand Hotel, Pune | Pune extension of RubyConf India organized by same folks organizing RubyConf India |
 | [Container Conference](https://www.containerconf.in/) | 3-4 Aug | Radisson Blu (Park Plaza), ORR, Bangalore | Container Conference is a developer focused conference on Docker, Managed Kubernetes/Container Services, Service Mesh, Kubernetes |


### PR DESCRIPTION
Updating the address for ReactFoo

<!--  Thanks for sending a pull request! You are awesome! :)
-->


**Details of the conference**:

- Website: https://reactfoo.in/2018-delhi/
- Date: 18 August 2018
- Venue: India International Centre, Max Mueller Marg, New Delhi
- Description: On React, front-end engineering and performance.
