### PR TITLE
Added JSFoo Pune 2019.

### DIFF
--- a/year-pages/2019-conferences-list.md
+++ b/year-pages/2019-conferences-list.md
@@ -2,4 +2,5 @@
 
 | Conference | Date | Venue | Description | Scholarship |
 |------------|------|-------|-------------|-------------|
-| [RubyConf India](https://www.rubyconfindia.org/) | 20-21 Jan | Resort Rio and Club Rio Royale, Goa | A global event complementing other RubyConf events across the world. This year it's a single track 2 day event, focused on the Language, Framework and Tools. | [Yes](https://www.rubyconfindia.org/scholarship/)
+| [RubyConf India](https://www.rubyconfindia.org/) | 20-21 Jan | Resort Rio and Club Rio Royale, Goa | A global event complementing other RubyConf events across the world. This year it's a single track 2 day event, focused on the Language, Framework and Tools. | [Yes](https://www.rubyconfindia.org/scholarship/) |
+| [JSFoo](https://jsfoo.in/2019-pune/) | 10 Jan | MCCIA TRADE TOWER, PUNE | The second Pune edition of India’s premier JavaScript conference | No

--- a/year-pages/2019-conferences-list.md
+++ b/year-pages/2019-conferences-list.md
@@ -3,4 +3,4 @@
 | Conference | Date | Venue | Description | Scholarship |
 |------------|------|-------|-------------|-------------|
 | [RubyConf India](https://www.rubyconfindia.org/) | 20-21 Jan | Resort Rio and Club Rio Royale, Goa | A global event complementing other RubyConf events across the world. This year it's a single track 2 day event, focused on the Language, Framework and Tools. | [Yes](https://www.rubyconfindia.org/scholarship/) |
-| [JSFoo](https://jsfoo.in/2019-pune/) | 10 Jan | MCCIA TRADE TOWER, PUNE | The second Pune edition of India’s premier JavaScript conference | No
+| [JSFoo](https://jsfoo.in/2019-pune/) | 10 Jan | MCCIA Trade Tower, Pune | The second Pune edition of India’s premier JavaScript conference. | No


### PR DESCRIPTION
**Details of the conference**:

- Website: https://jsfoo.in/2019-pune/
- Date: 10 Jan 2019
- Venue: MCCIA Trade Tower, Pune
- Description: The second Pune edition of India’s premier JavaScript conference
